### PR TITLE
Add Preset Arena results

### DIFF
--- a/presets/asterism.json
+++ b/presets/asterism.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1.02,
+  "temperature": 1.68,
+  "top_p": 0.17,
+  "top_k": 77,
+  "top_a": 0.42,
+  "typical": 1.0,
+  "tfs": 0.97,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/big-o.json
+++ b/presets/big-o.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1.01,
+  "temperature": 0.87,
+  "top_p": 0.99,
+  "top_k": 85,
+  "top_a": 0.0,
+  "typical": 0.68,
+  "tfs": 0.68,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/divine-intellect.json
+++ b/presets/divine-intellect.json
@@ -1,0 +1,16 @@
+{
+  "n": 1,
+  "rep_pen": 1.17,
+  "temperature": 1.31,
+  "top_p": 0.14,
+  "top_k": 49,
+  "top_a": 0.52,
+  "typical": 1.0,
+  "tfs": 1.0,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "epsilon_cutoff": 1.49,
+  "eta_cutoff": 10.42,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/midnight-enigma.json
+++ b/presets/midnight-enigma.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1.18,
+  "temperature": 0.98,
+  "top_p": 0.37,
+  "top_k": 100,
+  "top_a": 0.0,
+  "typical": 1.0,
+  "tfs": 1.0,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/shortwave.json
+++ b/presets/shortwave.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1.07,
+  "temperature": 1.53,
+  "top_p": 0.64,
+  "top_k": 33,
+  "top_a": 0.04,
+  "typical": 1.0,
+  "tfs": 1.0,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/simple-1.json
+++ b/presets/simple-1.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1.15,
+  "temperature": 0.7,
+  "top_p": 0.9,
+  "top_k": 20,
+  "top_a": 0.0,
+  "typical": 1.0,
+  "tfs": 1.0,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/space-alien.json
+++ b/presets/space-alien.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1.09,
+  "temperature": 1.31,
+  "top_p": 0.29,
+  "top_k": 72,
+  "top_a": 0.0,
+  "typical": 1.0,
+  "tfs": 1.0,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/starchat.json
+++ b/presets/starchat.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1,
+  "temperature": 0.2,
+  "top_p": 0.95,
+  "top_k": 50,
+  "top_a": 0.0,
+  "typical": 1.0,
+  "tfs": 1.0,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/tfs-with-top-a.json
+++ b/presets/tfs-with-top-a.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1.15,
+  "temperature": 0.7,
+  "top_p": 1.0,
+  "top_k": 0,
+  "top_a": 0.2,
+  "typical": 1.0,
+  "tfs": 0.95,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/titanic.json
+++ b/presets/titanic.json
@@ -1,0 +1,16 @@
+{
+  "n": 1,
+  "rep_pen": 1.21,
+  "temperature": 1.01,
+  "top_p": 0.21,
+  "top_k": 91,
+  "top_a": 0.75,
+  "typical": 1.0,
+  "tfs": 1.0,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "eta_cutoff": 10.78,
+  "encoder_repetition_penalty": 1.07,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}

--- a/presets/yara.json
+++ b/presets/yara.json
@@ -1,0 +1,14 @@
+{
+  "n": 1,
+  "rep_pen": 1.19,
+  "temperature": 0.82,
+  "top_p": 0.21,
+  "top_k": 72,
+  "top_a": 0.0,
+  "typical": 1.0,
+  "tfs": 1.0,
+  "rep_pen_range": 2048,
+  "rep_pen_slope": 0.0,
+  "sampler_order": [6, 0, 3, 1, 4, 2, 5],
+  "quiet": false
+}


### PR DESCRIPTION
First pass at including presets from oobabooga's preset arena experiment (https://github.com/oobabooga/oobabooga.github.io/blob/main/arena/results.md)

sampler_order adjusted to put repetition_penalty at the front to better match the default textgen-webui / llama.cpp ordering, hopefully!