### PR TITLE
fix presets sampler_order

### DIFF
--- a/presets/ace-of-spades.json
+++ b/presets/ace-of-spades.json
@@ -9,6 +9,6 @@
   "tfs": 0.8,
   "rep_pen_range": 2048,
   "rep_pen_slope": 7,
-  "sampler_order": [3, 2, 0, 5, 1, 4, 6],
+  "sampler_order": [6, 3, 2, 0, 5, 1, 4],
   "quiet": false
 }

--- a/presets/basic-coherence.json
+++ b/presets/basic-coherence.json
@@ -9,6 +9,6 @@
   "tfs": 0.87,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.3,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 5, 0, 2, 3, 1, 4],
   "quiet": false
 }

--- a/presets/best-guess.json
+++ b/presets/best-guess.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 2048,
   "rep_pen_slope": 3.4,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 5, 0, 2, 3, 1, 4],
   "quiet": false
 }

--- a/presets/coherent-creativity.json
+++ b/presets/coherent-creativity.json
@@ -9,6 +9,6 @@
   "tfs": 0.99,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.0,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 5, 0, 2, 3, 1, 4],
   "quiet": false
 }

--- a/presets/emperor-moth.json
+++ b/presets/emperor-moth.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.0,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 0, 1, 3, 4, 2, 5],
   "quiet": false
 }

--- a/presets/fandango.json
+++ b/presets/fandango.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.1,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 0, 1, 3, 4, 2, 5],
   "quiet": false
 }

--- a/presets/genesis.json
+++ b/presets/genesis.json
@@ -9,6 +9,6 @@
   "tfs": 0.98,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.1,
-  "sampler_order": [2, 0, 3, 5, 1, 4, 6],
+  "sampler_order": [6, 2, 0, 3, 5, 1, 4],
   "quiet": false
 }

--- a/presets/godlike.json
+++ b/presets/godlike.json
@@ -9,6 +9,6 @@
   "tfs": 0.97,
   "rep_pen_range": 1024,
   "rep_pen_slope": 0.7,
-  "sampler_order": [5, 4, 3, 2, 1, 0, 6],
+  "sampler_order": [6, 5, 4, 3, 2, 1, 0],
   "quiet": false
 }

--- a/presets/good-winds.json
+++ b/presets/good-winds.json
@@ -9,6 +9,6 @@
   "tfs": 0.9,
   "rep_pen_range": 1024,
   "rep_pen_slope": 0.7,
-  "sampler_order": [0, 1, 2, 3, 4, 5, 6],
+  "sampler_order": [6, 0, 1, 2, 3, 4, 5],
   "quiet": false
 }

--- a/presets/liminal-drift.json
+++ b/presets/liminal-drift.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 1024,
   "rep_pen_slope": 0.7,
-  "sampler_order": [4, 5, 1, 0, 2, 3, 6],
+  "sampler_order": [6, 4, 5, 1, 0, 2, 3],
   "quiet": false
 }

--- a/presets/low-rider.json
+++ b/presets/low-rider.json
@@ -9,6 +9,6 @@
   "tfs": 0.94,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.2,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 5, 0, 2, 3, 1, 4],
   "quiet": false
 }

--- a/presets/luna-moth.json
+++ b/presets/luna-moth.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.0,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 5, 0, 2, 3, 1, 4],
   "quiet": false
 }

--- a/presets/mayday.json
+++ b/presets/mayday.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 1024,
   "rep_pen_slope": 0.7,
-  "sampler_order": [0, 1, 2, 3, 4, 5, 6],
+  "sampler_order": [6, 0, 1, 2, 3, 4, 5],
   "quiet": false
 }

--- a/presets/morpho.json
+++ b/presets/morpho.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.0,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 0, 1, 3, 4, 2, 5],
   "quiet": false
 }

--- a/presets/ouroboros.json
+++ b/presets/ouroboros.json
@@ -9,6 +9,6 @@
   "tfs": 0.93,
   "rep_pen_range": 404,
   "rep_pen_slope": 0.8,
-  "sampler_order": [0, 5, 3, 2, 1, 4, 6],
+  "sampler_order": [6, 0, 5, 3, 2, 1, 4],
   "quiet": false
 }

--- a/presets/pleasing-results.json
+++ b/presets/pleasing-results.json
@@ -9,6 +9,6 @@
   "tfs": 0.9,
   "rep_pen_range": 2048,
   "rep_pen_slope": 6.8,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 5, 0, 2, 3, 1, 4],
   "quiet": false
 }

--- a/presets/pro-writer.json
+++ b/presets/pro-writer.json
@@ -9,6 +9,6 @@
   "tfs": 0.69,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.1,
-  "sampler_order": [3, 2, 5, 0, 1, 4, 6],
+  "sampler_order": [6, 3, 2, 5, 0, 1, 4],
   "quiet": false
 }

--- a/presets/sphinx-moth.json
+++ b/presets/sphinx-moth.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.0,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 0, 1, 3, 4, 2, 5],
   "quiet": false
 }

--- a/presets/storywriter.json
+++ b/presets/storywriter.json
@@ -9,6 +9,6 @@
   "tfs": 1.0,
   "rep_pen_range": 2048,
   "rep_pen_slope": 0.2,
-  "sampler_order": [5, 0, 2, 3, 1, 4, 6],
+  "sampler_order": [6, 5, 0, 2, 3, 1, 4],
   "quiet": false
 }


### PR DESCRIPTION
Fixed presets sampler_order now that koboldcpp from v1.34.2 actually takes these into account - c. f. https://github.com/LostRuins/koboldcpp/issues/305

I've copied the sampler_order from TavernAI's presets of the same name to the proxy's.