### PR TITLE
fix message context getting pruned in singleline.mjs

### DIFF
--- a/prompt-formats/singleline.mjs
+++ b/prompt-formats/singleline.mjs
@@ -160,7 +160,10 @@ Write ${assistant}'s next reply in a fictional chat between ${assistant} and ${u
   });
 
   for (const msg of lastMessages) {
-    prompt.push(msg);
+    prompt.push({
+      ...msg,
+      prunable: false,
+    });
   }
 
   if (impersonationPromptFound || last?.role === "user" || silentMessage) {


### PR DESCRIPTION
In singleline.mjs, in the spot right before the reply is generated, the last 2 messages in the chat are repeated for context. But if the context is full, they get pruned, which breaks the format. This just makes it so the 2 pseudo-messages that are placed right before the reply generation don't get pruned.